### PR TITLE
Add bee names to the tooltip.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 archivesBaseName = "beenfo"
-version = "1.15-fabric0.4.23-1.0.1"
+version = "1.15-fabric0.4.23-1.0.2"
 
 minecraft {
 }

--- a/src/main/java/de/guntram/mcmod/beenfo/Beenfo.java
+++ b/src/main/java/de/guntram/mcmod/beenfo/Beenfo.java
@@ -7,7 +7,7 @@ public class Beenfo implements ClientModInitializer
 {
     public static final String MODID = "beenfo";
     public static final String MODNAME = "Beenfo";
-    public static final String VERSION = "1.15-fabric0.4.23-1.0.1";
+    public static final String VERSION = "1.15-fabric0.4.23-1.0.2";
 
     @Override
     public void onInitializeClient() {

--- a/src/main/resources/assets/beenfo/lang/de_de.json
+++ b/src/main/resources/assets/beenfo/lang/de_de.json
@@ -1,4 +1,5 @@
 {
-    "tooltip.bees"              : "%d Bienen",
-    "tooltip.honey"             : "%s Honig"
+    "tooltip.bees"              : "§6%d Bienen",
+    "tooltip.honey"             : "§6%s Honig",
+    "tooltip.name"              : "§7- %s"
 }

--- a/src/main/resources/assets/beenfo/lang/en_us.json
+++ b/src/main/resources/assets/beenfo/lang/en_us.json
@@ -1,4 +1,5 @@
 {   
-    "tooltip.bees"              : "%d Bees",
-    "tooltip.honey"             : "%s Honey"
+    "tooltip.bees"              : "§6%d Bees",
+    "tooltip.honey"             : "§6%s Honey",
+    "tooltip.name"              : "§7- %s"
 }


### PR DESCRIPTION
Each bee name will show on its own line after the bee count, colored light grey.
Ensure the tooltip appears at the top, under the item name and before the advanced tooltip info.
Color the honey level and bee count gold so they pop out more.